### PR TITLE
Tweaks to docker builds and linting

### DIFF
--- a/dcbr-web/package-lock.json
+++ b/dcbr-web/package-lock.json
@@ -2110,6 +2110,12 @@
       "integrity": "sha1-l6ERlkmyEa0zaR2fn0hqjsn74KM=",
       "dev": true
     },
+    "amdefine": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
+    },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
@@ -4598,6 +4604,12 @@
           "dev": true
         }
       }
+    },
+    "css-parse": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/css-parse/-/css-parse-1.7.0.tgz",
+      "integrity": "sha1-Mh9s9zeCpv91ERE5D8BeLGV9jJs=",
+      "dev": true
     },
     "css-select": {
       "version": "2.0.2",
@@ -13488,6 +13500,62 @@
         }
       }
     },
+    "stylus": {
+      "version": "0.54.5",
+      "resolved": "https://registry.npmjs.org/stylus/-/stylus-0.54.5.tgz",
+      "integrity": "sha1-QrlWCTHKcJDOhRWnmLqeaqPW3Hk=",
+      "dev": true,
+      "requires": {
+        "css-parse": "1.7.x",
+        "debug": "*",
+        "glob": "7.0.x",
+        "mkdirp": "0.5.x",
+        "sax": "0.5.x",
+        "source-map": "0.1.x"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.0.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.0.6.tgz",
+          "integrity": "sha1-IRuvr0nlJbjNkyYNFKsTYVKz9Xo=",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.2",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
+        "sax": {
+          "version": "0.5.8",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.8.tgz",
+          "integrity": "sha1-1HLbIo6zMcJQaw6MFVJK25OdEsE=",
+          "dev": true
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": ">=0.0.4"
+          }
+        }
+      }
+    },
+    "stylus-loader": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/stylus-loader/-/stylus-loader-3.0.2.tgz",
+      "integrity": "sha512-+VomPdZ6a0razP+zinir61yZgpw2NfljeSsdUF5kJuEzlo3khXhY19Fn6l8QQz1GRJGtMCo8nG5C04ePyV7SUA==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.2",
+        "lodash.clonedeep": "^4.5.0",
+        "when": "~3.6.x"
+      }
+    },
     "subscriptions-transport-ws": {
       "version": "0.9.16",
       "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.16.tgz",
@@ -14711,6 +14779,20 @@
         "vue-resize": "^0.4.5"
       }
     },
+    "vuetify": {
+      "version": "1.5.16",
+      "resolved": "https://registry.npmjs.org/vuetify/-/vuetify-1.5.16.tgz",
+      "integrity": "sha512-yBgOsfurKQkeS+l+rrTQZ2bFk0D9ezjHhkuVM5A/yVzcg62sY2nfYaq/H++uezBWC9WYFrp/5OmSocJQcWn9Qw=="
+    },
+    "vuetify-loader": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/vuetify-loader/-/vuetify-loader-1.3.0.tgz",
+      "integrity": "sha512-emKS3GWpx+0kWRHfoxpDpLR4HaXvhDn9bYNQf+IaaD5iU5S3xktDyS0egG7dp/oHLQr1U/Ui9g2ElhZUkdgRqw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.2.0"
+      }
+    },
     "vuex": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.0.tgz",
@@ -15160,6 +15242,12 @@
         "tr46": "^1.0.1",
         "webidl-conversions": "^4.0.2"
       }
+    },
+    "when": {
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/when/-/when-3.6.4.tgz",
+      "integrity": "sha1-RztRfsFZ4rhQBUl6E5g/CVQS404=",
+      "dev": true
     },
     "which": {
       "version": "1.3.1",

--- a/dcbr-web/src/plugins/vuetify.ts
+++ b/dcbr-web/src/plugins/vuetify.ts
@@ -1,7 +1,8 @@
-import Vue from 'vue'
-import Vuetify from 'vuetify/lib'
-import 'vuetify/src/stylus/app.styl'
+import "vuetify/src/stylus/app.styl";
+
+import Vue from "vue";
+import Vuetify from "vuetify/lib";
 
 Vue.use(Vuetify, {
-  iconfont: 'md',
-})
+  iconfont: "md"
+});

--- a/dcbr-web/src/registerServiceWorker.ts
+++ b/dcbr-web/src/registerServiceWorker.ts
@@ -1,32 +1,30 @@
 /* tslint:disable:no-console */
+import { register } from "register-service-worker";
 
-import { register } from 'register-service-worker';
-
-if (process.env.NODE_ENV === 'production') {
+if (process.env.NODE_ENV === "production") {
   register(`${process.env.BASE_URL}service-worker.js`, {
     ready() {
       console.log(
-        'App is being served from cache by a service worker.\n' +
-        'For more details, visit https://goo.gl/AFskqB',
+        "App is being served from cache by a service worker.\n" + "For more details, visit https://goo.gl/AFskqB"
       );
     },
     registered() {
-      console.log('Service worker has been registered.');
+      console.log("Service worker has been registered.");
     },
     cached() {
-      console.log('Content has been cached for offline use.');
+      console.log("Content has been cached for offline use.");
     },
     updatefound() {
-      console.log('New content is downloading.');
+      console.log("New content is downloading.");
     },
     updated() {
-      console.log('New content is available; please refresh.');
+      console.log("New content is available; please refresh.");
     },
     offline() {
-      console.log('No internet connection found. App is running in offline mode.');
+      console.log("No internet connection found. App is running in offline mode.");
     },
     error(error) {
-      console.error('Error during service worker registration:', error);
-    },
+      console.error("Error during service worker registration:", error);
+    }
   });
 }

--- a/dcbr-web/src/store.ts
+++ b/dcbr-web/src/store.ts
@@ -1,16 +1,10 @@
-import Vue from 'vue';
-import Vuex from 'vuex';
+import Vue from "vue";
+import Vuex from "vuex";
 
 Vue.use(Vuex);
 
 export default new Vuex.Store({
-  state: {
-
-  },
-  mutations: {
-
-  },
-  actions: {
-
-  },
+  state: {},
+  mutations: {},
+  actions: {}
 });

--- a/dcbr-web/tslint.json
+++ b/dcbr-web/tslint.json
@@ -1,8 +1,6 @@
 {
   "defaultSeverity": "warning",
-  "extends": [
-    "tslint:recommended"
-  ],
+  "extends": [],
   "linterOptions": {
     "exclude": [
       "node_modules/**"

--- a/dcbr-web/tslint.json
+++ b/dcbr-web/tslint.json
@@ -7,7 +7,7 @@
     ]
   },
   "rules": {
-    "quotemark": [true, "single"],
+    "quotemark": [true, "double"],
     "indent": [true, "spaces", 2],
     "interface-name": false,
     "ordered-imports": false,

--- a/docker/manage
+++ b/docker/manage
@@ -262,7 +262,7 @@ start-dev)
   DEFAULT_CONTAINERS="dcbr-web-dev dcbr-api dcbr-db"
   _startupParams=$(getStartupParams $@)
   configureEnvironment $@
-  docker-compose up -d ${_startupParams} 
+  docker-compose up -d --build ${_startupParams} 
   docker-compose logs -f
  ;;
 start-api)


### PR DESCRIPTION
I added the `--build` parameter to the `./manage start-dev` command: the container will always be rebuilt when starting, it will take a few seconds longer, but it will prevent some of the issues we had so far.

I also fixed the linting errors that were being spit out to the console. If you keep having linting errors in the imports after saving the file, please make sure that `typescriptHero.imports.stringQuoteStyle` in your VSCode settings (File -> Preferences -> Settings) is set to double quotes.