### PR TITLE
Fix for django-post-office email priority issue

### DIFF
--- a/dcbr-api/email_service/tasks.py
+++ b/dcbr-api/email_service/tasks.py
@@ -63,7 +63,7 @@ def send_registration_email(email_addr):
             },
             render_on_delivery=True,
             attachments={"certificate.pdf": DEST_FILE},
-            priority="now",
+            # priority="now", # can't use now at this time: https://github.com/ui/django-post_office/issues/218
         )
 
     finally:

--- a/dcbr-api/email_service/views.py
+++ b/dcbr-api/email_service/views.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class EmailNotification(APIView):
-    def put(self, request, *args, **kwargs):
+    def post(self, request, *args, **kwargs):
 
         email_addr = self.kwargs["email_addr"]
 


### PR DESCRIPTION
Switching email test API endpoint to using POST, remove priority to work around django-post-office-bug