### PR TITLE
Add Caddy config to support vue-router

### DIFF
--- a/dcbr-web/openshift/config/Caddyfile
+++ b/dcbr-web/openshift/config/Caddyfile
@@ -13,6 +13,12 @@
     # Openly exposed health check endpoint for OpenShift
     status 200 /health
 
+    # Required for vue-router to work
+    rewrite {
+        regexp .*
+        to {path} /
+    }
+
     proxy /api {%DCBR_API_HOST%}:{%DCBR_API_PORT%} {
         transparent
         fail_timeout 0 # see https://github.com/mholt/caddy/issues/1925


### PR DESCRIPTION
This rule delegates routing to the vue router when in the webapp