### PR TITLE
API endpoint for public search

### DIFF
--- a/dcbr-api/api/serializers.py
+++ b/dcbr-api/api/serializers.py
@@ -1,4 +1,4 @@
-from rest_framework.serializers import ModelSerializer
+from rest_framework import serializers
 
 from .models import (
     Address,
@@ -12,7 +12,7 @@ from .models import (
 )
 
 
-class Address_Serializer(ModelSerializer):
+class Address_Serializer(serializers.ModelSerializer):
     class Meta:
         model = Address
         fields = (
@@ -28,13 +28,13 @@ class Address_Serializer(ModelSerializer):
         )
 
 
-class Association_Membership_Serializer(ModelSerializer):
+class Association_Membership_Serializer(serializers.ModelSerializer):
     class Meta:
         model = Association_Membership
         fields = ("id", "assoc_name")
 
 
-class Operation_Risk_Factor_Serializer(ModelSerializer):
+class Operation_Risk_Factor_Serializer(serializers.ModelSerializer):
     class Meta:
         model = Operation_Risk_Factor
         fields = (
@@ -48,7 +48,7 @@ class Operation_Risk_Factor_Serializer(ModelSerializer):
         )
 
 
-class Animal_Risk_Factor_Serializer(ModelSerializer):
+class Animal_Risk_Factor_Serializer(serializers.ModelSerializer):
     class Meta:
         model = Animal_Risk_Factor
         fields = (
@@ -65,7 +65,7 @@ class Animal_Risk_Factor_Serializer(ModelSerializer):
         )
 
 
-class Operator_Serializer(ModelSerializer):
+class Operator_Serializer(serializers.ModelSerializer):
     class Meta:
         model = Operator
         fields = (
@@ -83,7 +83,7 @@ class Operator_Serializer(ModelSerializer):
         )
 
 
-class Renewal_Serializer(ModelSerializer):
+class Renewal_Serializer(serializers.ModelSerializer):
     class Meta:
         model = Renewal
         fields = (
@@ -96,7 +96,7 @@ class Renewal_Serializer(ModelSerializer):
         )
 
 
-class Registration_Serializer(ModelSerializer):
+class Registration_Serializer(serializers.ModelSerializer):
     operator = Operator_Serializer()
     addresses = Address_Serializer(many=True)
     associations = Association_Membership_Serializer(many=True)
@@ -154,7 +154,15 @@ class Registration_Serializer(ModelSerializer):
         return registration
 
 
-class Inspection_Report_Serializer(ModelSerializer):
+class Inspection_Report_Serializer(serializers.ModelSerializer):
     class Meta:
         model = Inspection_Report
         fields = "__all__"
+
+
+class Operator_Search_Serializer(serializers.ModelSerializer):
+    registration_number = serializers.StringRelatedField()
+
+    class Meta:
+        model = Operator
+        fields = ("registration_number", "first_name", "last_name")

--- a/dcbr-api/api/urls.py
+++ b/dcbr-api/api/urls.py
@@ -25,6 +25,7 @@ schema_view = get_schema_view(
 router = routers.SimpleRouter()
 
 router.register(r"register", views.Registration_ViewSet, "Registration")
+router.register(r"search", views.Operator_Search_ViewSet)
 
 # fmt: off
 swaggerpatterns = [

--- a/dcbr-api/api/views.py
+++ b/dcbr-api/api/views.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from rest_framework import mixins, status, viewsets
@@ -82,6 +81,11 @@ class Operator_Search_ViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
                         ]
                     )
                 )
+                .intersection(
+                    Operator.objects.filter(
+                        registration_number__operator_status=Registration.ACTIVE
+                    )
+                )
                 .order_by("registration_number")
             )
         else:
@@ -91,7 +95,6 @@ class Operator_Search_ViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
 
     def list(self, request, *args, **kwargs):
         queryset = self.filter_queryset(self.get_queryset())
-
         page = self.paginate_queryset(queryset)
         if page is not None:
             serializer = self.get_serializer(page, many=True)


### PR DESCRIPTION
Member of public can search for an active registration via searching for last name or for registration number.  The search functionality returns a list with the records that meet the criteria.  To test if John Smith has registration number BC-DCBR-000001:

http://localhost:8080/api/search/?string=smith
http://localhost:8080/api/search/?string=bc-dcbr-000001
